### PR TITLE
Make PipeWire socket read-only

### DIFF
--- a/com.polyphone_soundfonts.polyphone.json
+++ b/com.polyphone_soundfonts.polyphone.json
@@ -15,7 +15,7 @@
         "--socket=pulseaudio",
         "--device=dri",
         "--filesystem=home",
-        "--filesystem=xdg-run/pipewire-0",
+        "--filesystem=xdg-run/pipewire-0:ro",
         "--share=network",
         "--env=TMPDIR=/var/tmp",
         "--env=ALSA_CONFIG_PATH=",


### PR DESCRIPTION
Flatpaks should not have write access to socket files, like `xdg-run/pipewire-0`. Bidirectional communication is possible regardless of the suffix, so a benevolent app sees no difference. While it shouldn't be possible in theory, it would be best to prevent the possibility of deleting or modifying the socket itself. Flathub maintainers typically request this for new submissions.

https://discourse.flathub.org/t/what-is-the-difference-if-the-pipewire-socket-is-read-only/11951/7